### PR TITLE
Add VPC/EC2 sample for terraform-review demo

### DIFF
--- a/.github/workflows/terraform-review.yml
+++ b/.github/workflows/terraform-review.yml
@@ -31,7 +31,7 @@ jobs:
             各指摘は mcp__github_inline_comment__create_inline_comment で該当行にインラインコメントとして投稿してください。
             全体サマリ（HIGH/MEDIUM/LOW の件数）は gh pr comment でトップレベルコメントとして投稿してください。
           claude_args: |
-            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --allowedTools "Read,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
       - name: Upload Claude execution log
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/terraform-review.yml
+++ b/.github/workflows/terraform-review.yml
@@ -18,7 +18,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: anthropics/claude-code-action@v1
+      - id: claude
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,3 +34,10 @@ jobs:
             レビュー結果は assistant メッセージではなく、必ず GitHub コメントとして投稿してください。
           claude_args: |
             --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+      - name: Upload Claude execution log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-execution-output
+          path: ${{ steps.claude.outputs.execution_file }}
+          if-no-files-found: warn

--- a/.github/workflows/terraform-review.yml
+++ b/.github/workflows/terraform-review.yml
@@ -22,5 +22,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          track_progress: true
-          prompt: "/terraform-review この PR の Terraform 差分をレビューしてください。"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            /terraform-review この PR の Terraform 差分をレビューしてください。
+            差分は `gh pr diff` で取得できます。
+            各指摘は mcp__github_inline_comment__create_inline_comment で該当行にインラインコメントとして投稿してください。
+            最後に全体サマリ（HIGH/MEDIUM/LOW の件数）を gh pr comment でトップレベルコメントとして投稿してください。
+            レビュー結果は assistant メッセージではなく、必ず GitHub コメントとして投稿してください。
+          claude_args: |
+            --allowedTools "Read,Glob,Grep,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/claude-code-terraform-review/main.tf
+++ b/claude-code-terraform-review/main.tf
@@ -75,4 +75,4 @@ resource "aws_instance" "web" {
   }
 }
 
-# trigger re-review: capture execution log to find minimal allowedTools (run A, baseline)
+# trigger re-review: capture execution log to find minimal allowedTools (run A, baseline retry)

--- a/claude-code-terraform-review/main.tf
+++ b/claude-code-terraform-review/main.tf
@@ -75,4 +75,4 @@ resource "aws_instance" "web" {
   }
 }
 
-# trigger re-review: agent mode + inline comments verification
+# trigger re-review: capture execution log to find minimal allowedTools (run A, baseline)

--- a/claude-code-terraform-review/main.tf
+++ b/claude-code-terraform-review/main.tf
@@ -75,4 +75,4 @@ resource "aws_instance" "web" {
   }
 }
 
-# trigger re-review: capture execution log to find minimal allowedTools (run A, baseline retry)
+# trigger re-review: run B, trimmed allowedTools (drop Glob/Grep) to confirm denials:0

--- a/claude-code-terraform-review/main.tf
+++ b/claude-code-terraform-review/main.tf
@@ -1,0 +1,76 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.instance_name}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr
+  map_public_ip_on_launch = true
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "web" {
+  name_prefix = "${var.instance_name}-sg-"
+  description = "Security group for ${var.instance_name}"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "web" {
+  ami                    = "ami-0d52744d6551d851e"
+  instance_type          = "t3.micro"
+  subnet_id              = aws_subnet.public.id
+  vpc_security_group_ids = [aws_security_group.web.id]
+
+  root_block_device {
+    volume_size = 20
+  }
+
+  tags = {
+    Name = var.instance_name
+  }
+}

--- a/claude-code-terraform-review/main.tf
+++ b/claude-code-terraform-review/main.tf
@@ -74,3 +74,5 @@ resource "aws_instance" "web" {
     Name = var.instance_name
   }
 }
+
+# trigger re-review: agent mode + inline comments verification

--- a/claude-code-terraform-review/provider.tf
+++ b/claude-code-terraform-review/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}

--- a/claude-code-terraform-review/variables.tf
+++ b/claude-code-terraform-review/variables.tf
@@ -1,0 +1,14 @@
+variable "instance_name" {
+  type    = string
+  default = "review-demo"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidr" {
+  type    = string
+  default = "10.0.1.0/24"
+}


### PR DESCRIPTION
terraform-review スキル検証用の VPC/EC2 構成を追加。意図的にレビュー対象となる設定（SSH 全開放・IMDSv2 未強制・EBS 非暗号化・AMI 直書き・タグ欠落）を含む。