### PR TITLE
Add terraform-plan-review sample (GHA plan + Claude review)

### DIFF
--- a/.claude/skills/terraform-plan-review/SKILL.md
+++ b/.claude/skills/terraform-plan-review/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: terraform-plan-review
+description: terraform plan の出力（JSON）をレビューする。HCL を静的に読むのではなく、provider に問い合わせた実際の差分（plan）を見て、replace（再作成）・delete（削除）・想定外の更新など「適用したら何が起きるか」のリスクを指摘する。「plan をレビュー」「この plan.json を見て」「/terraform-plan-review」などで使う。
+---
+
+# Terraform plan レビュー
+
+`terraform plan` の結果（`terraform show -json` の出力）をレビューし、適用時のリスクを指摘する。
+コードレビュー（HCL を静的に読む）とは別物で、**provider が返した実際の差分**を対象にする。
+コードを読むだけでは気づきにくい replace（破棄→再作成）・delete を最優先で拾う。
+
+このスキルは CI でそのまま動くよう、判断に必要な知識をスキル内に持たせている（外部プラグイン非依存）。
+
+## レビュー対象の特定
+
+1. 引数で渡された plan JSON ファイル（例 `plan.json`）を `Read` する
+   - 大きくて読みきれない場合は `Bash(jq '.resource_changes' plan.json)` で差分配列だけに絞る
+2. `.resource_changes[]` を走査する。各要素の `.address` と `.change.actions` を見る
+
+## アクション分類（plan レビューの肝）
+
+`.change.actions` の配列でアクションを判定する。
+
+| `actions` | 意味 |
+|---|---|
+| `["no-op"]` | 変更なし（無視） |
+| `["create"]` | 新規作成 |
+| `["update"]` | インプレース更新 |
+| `["delete"]` | 削除 |
+| `["delete","create"]` | replace（破棄→再作成） |
+| `["create","delete"]` | replace（create_before_destroy。新規作成→旧削除） |
+
+**replace と delete を最優先で拾う**。create / update / no-op は件数だけ数える。
+
+replace の理由は `.change.replace_paths`（再作成を招いた属性パス）で確認できる。指摘に添えると親切。
+
+## 重大度
+
+| 重大度 | 基準 |
+|---|---|
+| HIGH | 状態を持つリソース（RDS / EBS / EC2 のルートボリューム / S3 / DynamoDB 等）の delete・replace（データ消失）。PR の意図に無い想定外の delete |
+| MEDIUM | ステートレスなリソースの replace（ダウンタイムのみ）。多数リソースへの波及 |
+| LOW | 影響の小さい update など |
+
+迷ったら一段下げる。憶測で HIGH を付けない。plan から読み取れる事実だけで判断する。
+1つの変更が N 個のリソースに波及する場合は件数を明示する。
+
+## センシティブ値の扱い（必須・public リポジトリ前提）
+
+plan JSON には Terraform が `sensitive` と印を付けない値（アカウントID・ARN・各属性の before/after）も載る。
+**これらの生値をコメントに出さない。** 出力してよいのは次だけ:
+
+- リソースアドレス（例 `aws_instance.web`）
+- アクション（replace / delete など）
+- replace を招いた属性の**名前**（例 `ami` が変わった）。値そのものは出さない
+- なぜ危険か・確認すべきこと（一般的な説明）
+
+`before` / `after` / `sensitive_values` / `after_unknown` の中身は引用しない。
+
+## 出力形式
+
+最初に1行サマリ（create / update / delete / **replace** の件数）。続けて replace / delete を重大度の高い順に列挙する。
+
+```
+## Terraform plan レビュー結果
+
+create: 0 / update: 0 / delete: 0 / replace: 1
+
+### [HIGH] aws_instance.web が replace（破棄→再作成）される
+- アクション: replace（delete → create）
+- 要因: `ami` 属性の変更（ForceNew）
+- リスク: インスタンス再作成でルート EBS のデータが失われ、ダウンタイムが発生する
+- 確認: 意図した AMI 更新か。データ移行・スナップショットが必要でないか
+```
+
+- replace / delete がゼロなら「破壊的変更なし（create/update のみ）」と明記する。無理に粗探ししない
+- 1つの指摘は3〜5行に収める。冗長な前置きを書かない

--- a/.github/workflows/terraform-plan-review.yml
+++ b/.github/workflows/terraform-plan-review.yml
@@ -1,0 +1,46 @@
+name: terraform-plan-review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "claude-code-terraform-plan-review/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  plan-review:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: claude-code-terraform-plan-review
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ap-northeast-1
+      - uses: hashicorp/setup-terraform@v4
+      # backend.tf（S3 backend）をコミットしておくと、init がローカルで apply 済みの state（S3 上）を読む。
+      - run: terraform init
+      - run: terraform plan -out=tfplan
+      - run: terraform show -json tfplan > plan.json
+      - id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            /terraform-plan-review claude-code-terraform-plan-review/plan.json をレビューしてください。
+            replace / delete を中心に、適用時のリスクを指摘してください。
+            結果は gh pr comment でトップレベルコメントとして投稿してください。
+          claude_args: |
+            --allowedTools "Read,Bash(jq:*),Bash(gh pr comment:*),Bash(gh pr view:*)"

--- a/.github/workflows/terraform-plan-review.yml
+++ b/.github/workflows/terraform-plan-review.yml
@@ -26,7 +26,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ap-northeast-1
       - uses: hashicorp/setup-terraform@v4
-      # backend.tf（S3 backend）をコミットしておくと、init がローカルで apply 済みの state（S3 上）を読む。
       - run: terraform init
       - run: terraform plan -out=tfplan
       - run: terraform show -json tfplan > plan.json

--- a/claude-code-terraform-plan-review/.terraform.lock.hcl
+++ b/claude-code-terraform-plan-review/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.52.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:lpXqosKH8yAahK3SA1P5Pdy1ziXJcY+blUidY0q9yGk=",
+    "zh:1ab1d78f2336fed42b4e13fa0077a0be9d86a7899897cda5b9f1a60051ec2e93",
+    "zh:1df11f5f252030803939a1c778931dbdcee1b1070b38b98d9a8cbfc26c2aeb8e",
+    "zh:20ec9af03c0c1f2f8582a8805d43a4cd1a0a65082308e00f025d87605715a88f",
+    "zh:2d5562ed0e7cb0892fb537c7989d25fdde1d0ac1f3a768ba15fa087985f2a0f5",
+    "zh:40d64f668961a172355c3d11d258e19172ffafb421c40d89266b129ed8f92a5d",
+    "zh:497792bccc33001247473bc32a148c067982cb3d245b8f3610afb920635d2235",
+    "zh:8011f9167082af74ed9257582a83d54e889388656597721b2691797f1dd6fb58",
+    "zh:8b10d1bbca51b0da1e1be0967ce75b039f2d5d86f2ca7339994a92d35cdf47a8",
+    "zh:9549647dbf7c913512c26fed6badd7bf24a29a36c2bd308536849303a85427da",
+    "zh:97c4b726cdbe48166f4b9e6a1230312a7933dc19dd139d941ca6aca86706eb33",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a484bc8166278b546bfe53698fa9e0a919dffe3bfda3c8bf8a0fc6811b5b9e66",
+    "zh:aa96e76bd9f93e5395a553fccec485554a74acae46b3834b1296374eba4f010f",
+    "zh:cf290ee3d0dfe91b596445f860440d9f18826f7395ff785f83f70d36cedadd1c",
+    "zh:d56b6a79207663673f66d9ed378d705c1bd1b4d117eeb5e2be3938cf1b75b7be",
+    "zh:febef068317f8e49bd438ccdf2f54345fc3bc4b80a2699d9ab3c449d7e521d8e",
+  ]
+}

--- a/claude-code-terraform-plan-review/backend.tf.sample
+++ b/claude-code-terraform-plan-review/backend.tf.sample
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "<STATE_BUCKET>"
+    key          = "claude-code-terraform-plan-review/terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+  }
+}

--- a/claude-code-terraform-plan-review/main.tf
+++ b/claude-code-terraform-plan-review/main.tf
@@ -1,0 +1,68 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.instance_name}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr
+  map_public_ip_on_launch = true
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "web" {
+  name_prefix = "${var.instance_name}-sg-"
+  description = "Security group for ${var.instance_name}"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "web" {
+  ami                    = var.ami_id
+  instance_type          = "t3.micro"
+  subnet_id              = aws_subnet.public.id
+  vpc_security_group_ids = [aws_security_group.web.id]
+
+  root_block_device {
+    volume_size = 20
+  }
+
+  tags = {
+    Name = var.instance_name
+  }
+}

--- a/claude-code-terraform-plan-review/provider.tf
+++ b/claude-code-terraform-plan-review/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}

--- a/claude-code-terraform-plan-review/variables.tf
+++ b/claude-code-terraform-plan-review/variables.tf
@@ -1,0 +1,19 @@
+variable "instance_name" {
+  type    = string
+  default = "review-demo"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidr" {
+  type    = string
+  default = "10.0.1.0/24"
+}
+
+variable "ami_id" {
+  type    = string
+  default = "ami-0d52744d6551d851e"
+}


### PR DESCRIPTION
## 概要

GitHub Actions で `terraform plan` を実行し、その JSON 出力を Claude Code にレビューさせるサンプルです。replace / delete などの適用時リスクを PR コメントに出します。

## 追加物

- `.claude/skills/terraform-plan-review/SKILL.md` — `resource_changes[]` の `actions` を分類し、replace / delete を重大度付きで指摘するスキル
- `.github/workflows/terraform-plan-review.yml` — `terraform plan` → `terraform show -json` → claude-code-action でレビュー投稿
- `claude-code-terraform-plan-review/` — 検証用の最小構成（VPC / EC2）。実 `backend.tf` は gitignore、`backend.tf.sample` を同梱

## 注意

- 参考用サンプルです。このリポジトリでそのまま動かす前提ではなく、各自カスタマイズして使う想定（動作保証なし）。
- 実 `backend.tf`（バケット名にアカウントID を含む）は gitignore。`backend.tf.sample` の `<STATE_BUCKET>` を環境に合わせて差し替えて使います。
- trigger は `on: pull_request`。public リポジトリで外部 PR から勝手に起動しないよう、Actions の「外部コントリビューターは承認制」設定を推奨。

🤖 Generated with [Claude Code](https://claude.com/claude-code)