### PR TITLE
terraform-conftest-opa: add plan JSON policy check sample with Conftest/OPA

### DIFF
--- a/.github/workflows/terraform-opa-check.yml
+++ b/.github/workflows/terraform-opa-check.yml
@@ -1,0 +1,39 @@
+name: terraform-opa-check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - "terraform-conftest-opa/**"
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+jobs:
+  opa-check:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform-conftest-opa
+    steps:
+      - uses: actions/checkout@v7
+      - uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ap-northeast-1
+      - uses: hashicorp/setup-terraform@v4
+      - run: terraform init
+      - run: terraform plan -out=tfplan
+      - run: terraform show -json tfplan > plan.json
+      - shell: bash
+        run: |
+          docker run --rm -v "$PWD":/project \
+            openpolicyagent/conftest:v0.68.2 \
+            test plan.json --policy policy --output json | tee conftest-result.json
+      - if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: conftest-result
+          path: terraform-conftest-opa/conftest-result.json

--- a/terraform-conftest-opa/backend.tf
+++ b/terraform-conftest-opa/backend.tf
@@ -1,0 +1,8 @@
+terraform {
+  backend "s3" {
+    bucket       = "<STATE_BUCKET>"
+    key          = "terraform-conftest-opa/terraform.tfstate"
+    region       = "ap-northeast-1"
+    use_lockfile = true
+  }
+}

--- a/terraform-conftest-opa/main.tf
+++ b/terraform-conftest-opa/main.tf
@@ -1,0 +1,49 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+
+  tags = {
+    Name        = "${var.instance_name}-vpc"
+    Environment = "dev"
+    Owner       = "sato.masaki"
+  }
+}
+
+resource "aws_security_group" "web" {
+  name_prefix = "${var.instance_name}-sg-"
+  description = "Security group for ${var.instance_name}"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    description = "HTTP from office"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["203.0.113.0/24"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "${var.instance_name}-sg"
+    Environment = "dev"
+    Owner       = "sato.masaki"
+  }
+}
+
+resource "aws_ebs_volume" "data" {
+  availability_zone = "ap-northeast-1a"
+  size              = 10
+  encrypted         = true
+
+  tags = {
+    Name        = "${var.instance_name}-vol"
+    Environment = "dev"
+    Owner       = "sato.masaki"
+  }
+}

--- a/terraform-conftest-opa/policy/network.rego
+++ b/terraform-conftest-opa/policy/network.rego
@@ -1,0 +1,11 @@
+package main
+
+deny contains msg if {
+	some change in input.resource_changes
+	change.type == "aws_security_group"
+	change.change.actions[_] == "create"
+	some ingress in change.change.after.ingress
+	some cidr in ingress.cidr_blocks
+	cidr == "0.0.0.0/0"
+	msg := sprintf("%s: ingress open to 0.0.0.0/0 (port %d)", [change.address, ingress.from_port])
+}

--- a/terraform-conftest-opa/policy/network.rego
+++ b/terraform-conftest-opa/policy/network.rego
@@ -3,7 +3,8 @@ package main
 deny contains msg if {
 	some change in input.resource_changes
 	change.type == "aws_security_group"
-	change.change.actions[_] == "create"
+	some action in change.change.actions
+	action in {"create", "update"}
 	some ingress in change.change.after.ingress
 	some cidr in ingress.cidr_blocks
 	cidr == "0.0.0.0/0"

--- a/terraform-conftest-opa/policy/storage.rego
+++ b/terraform-conftest-opa/policy/storage.rego
@@ -1,0 +1,9 @@
+package main
+
+deny contains msg if {
+	some change in input.resource_changes
+	change.type == "aws_ebs_volume"
+	change.change.actions[_] == "create"
+	not change.change.after.encrypted
+	msg := sprintf("%s: EBS volume not encrypted", [change.address])
+}

--- a/terraform-conftest-opa/policy/storage.rego
+++ b/terraform-conftest-opa/policy/storage.rego
@@ -3,7 +3,8 @@ package main
 deny contains msg if {
 	some change in input.resource_changes
 	change.type == "aws_ebs_volume"
-	change.change.actions[_] == "create"
+	some action in change.change.actions
+	action in {"create", "update"}
 	not change.change.after.encrypted
 	msg := sprintf("%s: EBS volume not encrypted", [change.address])
 }

--- a/terraform-conftest-opa/policy/tags.rego
+++ b/terraform-conftest-opa/policy/tags.rego
@@ -1,0 +1,15 @@
+package main
+
+required_tags := {"Environment", "Owner"}
+
+taggable_types := {"aws_vpc", "aws_security_group", "aws_ebs_volume", "aws_instance"}
+
+deny contains msg if {
+	some change in input.resource_changes
+	taggable_types[change.type]
+	change.change.actions[_] == "create"
+	tags := object.get(change.change.after, "tags", {})
+	missing := required_tags - {k | some k, _ in tags}
+	count(missing) > 0
+	msg := sprintf("%s %s: required tags missing: %v", [change.type, change.address, missing])
+}

--- a/terraform-conftest-opa/policy/tags.rego
+++ b/terraform-conftest-opa/policy/tags.rego
@@ -7,7 +7,8 @@ taggable_types := {"aws_vpc", "aws_security_group", "aws_ebs_volume", "aws_insta
 deny contains msg if {
 	some change in input.resource_changes
 	taggable_types[change.type]
-	change.change.actions[_] == "create"
+	some action in change.change.actions
+	action in {"create", "update"}
 	tags := object.get(change.change.after, "tags", {})
 	missing := required_tags - {k | some k, _ in tags}
 	count(missing) > 0

--- a/terraform-conftest-opa/provider.tf
+++ b/terraform-conftest-opa/provider.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "ap-northeast-1"
+}

--- a/terraform-conftest-opa/variables.tf
+++ b/terraform-conftest-opa/variables.tf
@@ -1,0 +1,9 @@
+variable "instance_name" {
+  type    = string
+  default = "opa-demo"
+}
+
+variable "vpc_cidr" {
+  type    = string
+  default = "10.0.0.0/16"
+}


### PR DESCRIPTION
Terraform plan の JSON を Conftest（OPA）でポリシーチェックする最小サンプル。

- `terraform plan -out=tfplan` → `terraform show -json` → `conftest test` の3ステップ
- ルールは3つ（必須タグ / SG ingress 0.0.0.0/0 / EBS暗号化）
- conftest は公式Dockerイメージ（`openpolicyagent/conftest`）で実行
- ワークフローは `shell: bash` を明示し、pipefailを自動で有効化

ブログ記事のサンプルコードです。